### PR TITLE
Extract clients from orders, add dedicated POS flow, and move access control to config

### DIFF
--- a/app/Filament/Pages/Pos.php
+++ b/app/Filament/Pages/Pos.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Filament\Resources\OrderResource;
+use Filament\Navigation\NavigationItem;
+use Filament\Pages\Page;
+
+class Pos extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-calculator';
+
+    protected static ?string $navigationLabel = 'POS';
+
+    protected static ?string $navigationGroup = 'Sales Management';
+
+    protected static ?int $navigationSort = 1;
+
+    protected static string $view = 'filament.pages.pos';
+
+    public function mount(): void
+    {
+        abort_unless(static::canAccess(), 403);
+
+        $this->redirect(OrderResource::getUrl('create'), navigate: true);
+    }
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->can('page_Pos') && OrderResource::canCreate();
+    }
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        return static::canAccess();
+    }
+
+    public static function getNavigationItems(): array
+    {
+        return [
+            NavigationItem::make(static::getNavigationLabel())
+                ->group(static::getNavigationGroup())
+                ->icon(static::getNavigationIcon())
+                ->sort(static::getNavigationSort())
+                ->isActiveWhen(fn (): bool => request()->routeIs('filament.admin.resources.orders.create'))
+                ->url(OrderResource::getUrl('create')),
+        ];
+    }
+}

--- a/app/Filament/Resources/ClientResource.php
+++ b/app/Filament/Resources/ClientResource.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ClientResource\Pages;
+use App\Models\Client;
+use Filament\Forms;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Form;
+use Filament\Infolists;
+use Filament\Infolists\Infolist;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class ClientResource extends Resource
+{
+    protected static ?string $model = Client::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-user-group';
+
+    protected static ?int $navigationSort = 3;
+
+    protected static ?string $navigationGroup = 'Sales Management';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Section::make('Client details')
+                    ->description('Store reusable customer information for future POS orders.')
+                    ->schema(static::clientFormSchema())
+                    ->columns(2),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('phone')
+                    ->searchable()
+                    ->placeholder('No phone'),
+                Tables\Columns\TextColumn::make('address')
+                    ->searchable()
+                    ->limit(40)
+                    ->placeholder('No address'),
+                Tables\Columns\TextColumn::make('orders_count')
+                    ->counts('orders')
+                    ->label('Orders')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->since()
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\TrashedFilter::make(),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\ForceDeleteBulkAction::make(),
+                    Tables\Actions\RestoreBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                Infolists\Components\Section::make('Client profile')
+                    ->schema([
+                        Infolists\Components\TextEntry::make('name')
+                            ->weight('semibold'),
+                        Infolists\Components\TextEntry::make('phone')
+                            ->placeholder('No phone'),
+                        Infolists\Components\TextEntry::make('address')
+                            ->placeholder('No address')
+                            ->columnSpanFull(),
+                        Infolists\Components\TextEntry::make('notes')
+                            ->placeholder('No notes')
+                            ->columnSpanFull(),
+                    ])
+                    ->columns(2),
+                Infolists\Components\Section::make('Activity')
+                    ->schema([
+                        Infolists\Components\TextEntry::make('orders_count')
+                            ->state(fn (Client $record): int => $record->orders()->count())
+                            ->label('Orders placed'),
+                        Infolists\Components\TextEntry::make('created_at')
+                            ->dateTime(),
+                        Infolists\Components\TextEntry::make('updated_at')
+                            ->dateTime(),
+                    ])
+                    ->columns(3),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListClients::route('/'),
+            'create' => Pages\CreateClient::route('/create'),
+            'view' => Pages\ViewClient::route('/{record}'),
+            'edit' => Pages\EditClient::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withCount('orders')
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
+            ]);
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string
+    {
+        return $record->name;
+    }
+
+    public static function getGloballySearchableAttributes(): array
+    {
+        return [
+            'name',
+            'phone',
+            'address',
+        ];
+    }
+
+    public static function getGlobalSearchResultDetails(Model $record): array
+    {
+        return [
+            'Phone' => $record->phone ?: 'No phone',
+            'Address' => $record->address ?: 'No address',
+        ];
+    }
+
+    public static function clientFormSchema(): array
+    {
+        return [
+            Forms\Components\TextInput::make('name')
+                ->required()
+                ->maxLength(255),
+            Forms\Components\TextInput::make('phone')
+                ->tel()
+                ->maxLength(255),
+            Forms\Components\TextInput::make('address')
+                ->maxLength(255)
+                ->columnSpanFull(),
+            Forms\Components\Textarea::make('notes')
+                ->rows(4)
+                ->columnSpanFull(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ClientResource/Pages/CreateClient.php
+++ b/app/Filament/Resources/ClientResource/Pages/CreateClient.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ClientResource\Pages;
+
+use App\Filament\Resources\ClientResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateClient extends CreateRecord
+{
+    protected static string $resource = ClientResource::class;
+}

--- a/app/Filament/Resources/ClientResource/Pages/EditClient.php
+++ b/app/Filament/Resources/ClientResource/Pages/EditClient.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Filament\Resources\ClientResource\Pages;
+
+use App\Filament\Resources\ClientResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditClient extends EditRecord
+{
+    protected static string $resource = ClientResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+            Actions\ForceDeleteAction::make(),
+            Actions\RestoreAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ClientResource/Pages/ListClients.php
+++ b/app/Filament/Resources/ClientResource/Pages/ListClients.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\ClientResource\Pages;
+
+use App\Filament\Resources\ClientResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListClients extends ListRecords
+{
+    protected static string $resource = ClientResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ClientResource/Pages/ViewClient.php
+++ b/app/Filament/Resources/ClientResource/Pages/ViewClient.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Filament\Resources\ClientResource\Pages;
+
+use App\Filament\Resources\ClientResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewClient extends ViewRecord
+{
+    protected static string $resource = ClientResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/OrderResource.php
+++ b/app/Filament/Resources/OrderResource.php
@@ -2,138 +2,188 @@
 
 namespace App\Filament\Resources;
 
-use Filament\Forms;
+use App\Filament\Resources\OrderResource\Pages;
+use App\Models\Client;
 use App\Models\Order;
 use App\Models\Product;
+use AymanAlhattami\FilamentDateScopesFilter\DateScopeFilter;
+use Filament\Forms;
+use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Components\Grid;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
-use Filament\Forms\Form;
-use Filament\Tables\Table;
+use Filament\Infolists;
+use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
-use Filament\Forms\Components\Select;
-use Filament\Forms\Components\Section;
-use Filament\Forms\Components\Repeater;
-use Filament\Tables\Actions\ViewAction;
-use Filament\Tables\Columns\TextColumn;
-use Illuminate\Database\Eloquent\Model;
-use Filament\Forms\Components\TextInput;
-use Filament\Tables\Actions\DeleteAction;
-use Filament\Tables\Columns\ToggleColumn;
+use Filament\Tables;
+use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
-use Filament\Tables\Filters\TrashedFilter;
-use Filament\Tables\Actions\BulkActionGroup;
-use Filament\Tables\Columns\Summarizers\Sum;
-use Filament\Forms\Components\Actions\Action;
-use Filament\Tables\Actions\DeleteBulkAction;
-use Filament\Tables\Actions\RestoreBulkAction;
-use App\Filament\Resources\OrderResource\Pages;
-use Filament\Tables\Actions\ForceDeleteBulkAction;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
-use AymanAlhattami\FilamentDateScopesFilter\DateScopeFilter;
 
 class OrderResource extends Resource
 {
     protected static ?string $model = Order::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-document-text';
+    protected static ?string $navigationIcon = 'heroicon-o-shopping-bag';
 
-    protected static ?int $navigationSort = 3;
+    protected static ?int $navigationSort = 2;
 
-    protected static ?string $navigationGroup = 'Stocks Management';
+    protected static ?string $navigationGroup = 'Sales Management';
 
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
-                Section::make('Client')
-                    ->description('Client details')
-                    ->collapsible()
+                Grid::make([
+                    'default' => 1,
+                    'xl' => 1,
+                ])
                     ->schema([
-                        TextInput::make('client_name')
-                            ->required()
-                            ->maxLength(255),
-                        TextInput::make('client_phone')
-                            ->tel()
-                            ->required()
-                            ->maxLength(255),
-                        TextInput::make('client_address')
-                            ->required()
-                            ->maxLength(255),
-                    ])->columns(3),
-
-                Section::make('Products')
-                    ->description('Ordered products')
-                    ->collapsible()
-                    ->schema([
-                        Repeater::make('orderProducts')
-                            ->label('')
-                            ->relationship()
+                        Section::make('POS cart')
+                            ->description('Build the order quickly. Product prices are pulled from inventory automatically.')
+                            ->columnSpanFull()
                             ->schema([
-                                Select::make('product_id')
-                                    ->relationship(name: 'product', titleAttribute: 'name')
-                                    ->required()
-                                    ->native(false)
-                                    ->searchable()
-                                    ->preload()
-                                    ->reactive()
-                                    ->afterStateUpdated(function ($state, callable $set) {
-                                        $product = Product::find($state);
-                                        if ($product) {
-                                            $set('price', $product->price);
-                                        }
-                                    })
-                                    // Disable options that are already selected in other rows
-                                    ->disableOptionWhen(function ($value, $state, Get $get) {
-                                        return collect($get('../*.product_id'))
-                                            ->reject(fn($id) => $id == $state)
-                                            ->filter()
-                                            ->contains($value);
-                                    }),
-                                TextInput::make('quantity')
-                                    ->default(1)
-                                    ->integer()
-                                    ->required()
-                                    ->minValue(1),
-                                TextInput::make('price')
-                                    ->numeric()
-                                    ->prefix('XFA')
-                                    ->readOnly()
-                                    ->required(),
-                            ])
-                            ->columns(3)
-                            // Repeatable field is live so that it will trigger the state update on each change
-                            ->live()
-                            // After adding a new row, we need to update the totals
-                            ->afterStateUpdated(function (Get $get, Set $set) {
-                                self::updateTotals($get, $set);
-                            })
-                            // After deleting a row, we need to update the totals
-                            ->deleteAction(
-                                fn(Action $action) => $action->after(fn(Get $get, Set $set) => self::updateTotals($get, $set)),
-                            )
-                            // Disable reordering
-                            ->reorderable(false),
+                                Repeater::make('orderProducts')
+                                    ->label('')
+                                    ->relationship()
+                                    ->defaultItems(1)
+                                    ->minItems(1)
+                                    ->schema([
+                                        Select::make('product_id')
+                                            ->label('Product')
+                                            ->relationship(name: 'product', titleAttribute: 'name')
+                                            ->getOptionLabelFromRecordUsing(fn (Product $record): string => "{$record->name} · {$record->quantity} in stock")
+                                            ->searchable(['name'])
+                                            ->preload()
+                                            ->native(false)
+                                            ->required()
+                                            ->live()
+                                            ->columnSpan([
+                                                'default' => 1,
+                                                'xl' => 4,
+                                            ])
+                                            ->afterStateUpdated(function ($state, Set $set, Get $get): void {
+                                                $product = Product::find($state);
+                                                $set('price', $product?->price ?? null);
+                                                self::updateTotals($get, $set);
+                                            })
+                                            ->disableOptionWhen(function ($value, $state, Get $get): bool {
+                                                return collect($get('../*.product_id'))
+                                                    ->reject(fn ($id) => $id == $state)
+                                                    ->filter()
+                                                    ->contains($value);
+                                            }),
+                                        TextInput::make('quantity')
+                                            ->integer()
+                                            ->default(1)
+                                            ->minValue(1)
+                                            ->required()
+                                            ->live(onBlur: true)
+                                            ->suffix('pcs')
+                                            ->extraInputAttributes(['class' => 'text-base font-semibold text-center'])
+                                            ->columnSpan([
+                                                'default' => 1,
+                                                'md' => 2,
+                                                'xl' => 2,
+                                            ])
+                                            ->afterStateUpdated(fn (Get $get, Set $set) => self::updateTotals($get, $set)),
+                                        Placeholder::make('unit_price')
+                                            ->label('Unit price')
+                                            ->columnSpan([
+                                                'default' => 1,
+                                                'md' => 2,
+                                                'xl' => 1,
+                                            ])
+                                            ->content(fn (Get $get): string => self::formatMoney((float) ($get('price') ?? 0))),
+                                        Placeholder::make('line_total')
+                                            ->label('Line total')
+                                            ->columnSpan([
+                                                'default' => 1,
+                                                'md' => 2,
+                                                'xl' => 1,
+                                            ])
+                                            ->content(function (Get $get): string {
+                                                $price = (float) ($get('price') ?? 0);
+                                                $quantity = (int) ($get('quantity') ?? 0);
+
+                                                return self::formatMoney($price * $quantity);
+                                            }),
+                                        Hidden::make('price')
+                                            ->default(0)
+                                            ->required(),
+                                    ])
+                                    ->columns([
+                                        'default' => 1,
+                                        'md' => 4,
+                                        'xl' => 8,
+                                    ])
+                                    ->addActionLabel('Add product')
+                                    ->live()
+                                    ->afterStateUpdated(fn (Get $get, Set $set) => self::updateTotals($get, $set))
+                                    ->deleteAction(
+                                        fn (Action $action) => $action->after(fn (Get $get, Set $set) => self::updateTotals($get, $set)),
+                                    )
+                                    ->reorderable(false),
+                            ]),
+                        Grid::make(1)
+                            ->columnSpanFull()
+                            ->schema([
+                                Section::make('Client')
+                                    ->description('Pick an existing customer or leave this empty for a walk-in sale.')
+                                    ->schema([
+                                        Select::make('client_id')
+                                            ->label('Client')
+                                            ->relationship(name: 'client', titleAttribute: 'name', modifyQueryUsing: fn (Builder $query) => $query->orderBy('name'))
+                                            ->searchable(['name', 'phone', 'address'])
+                                            ->getOptionLabelFromRecordUsing(function (Client $record): string {
+                                                $phone = $record->phone ? " · {$record->phone}" : '';
+
+                                                return "{$record->name}{$phone}";
+                                            })
+                                            ->preload()
+                                            ->native(false)
+                                            ->placeholder('Walk-in customer')
+                                            ->createOptionForm(ClientResource::clientFormSchema())
+                                            ->createOptionUsing(fn (array $data): int => Client::create($data)->getKey())
+                                            ->helperText('The order can be saved without a client.')
+                                            ->columnSpanFull(),
+                                        Hidden::make('total')
+                                            ->default(0)
+                                            ->visibleOn('create')
+                                            ->dehydrated(),
+                                    ]),
+                                Section::make('Order summary')
+                                    ->hiddenOn('create')
+                                    ->schema([
+                                        Placeholder::make('items_count')
+                                            ->label('Items')
+                                            ->content(function (Get $get): string {
+                                                return (string) collect($get('orderProducts'))
+                                                    ->filter(fn ($item) => filled($item['product_id'] ?? null))
+                                                    ->count();
+                                            }),
+                                        Placeholder::make('cashier')
+                                            ->content(fn (): string => auth()->user()->name),
+                                        TextInput::make('total')
+                                            ->prefix('XFA')
+                                            ->numeric()
+                                            ->readOnly()
+                                            ->required()
+                                            ->afterStateHydrated(fn (Get $get, Set $set) => self::updateTotals($get, $set)),
+                                        Forms\Components\Toggle::make('delivered')
+                                            ->helperText('Mark the order as handed over to the client.')
+                                            ->visibleOn('edit'),
+                                    ]),
+                            ]),
                     ]),
-                Section::make('Total')
-                    ->description('Total to pay')
-                    ->collapsible()
-                    ->schema([
-                        TextInput::make('total')
-                            ->prefix('XFA')
-                            ->required()
-                            ->numeric()
-                            ->readOnly()
-                            // This enables us to display the subtotal on the edit page load
-                            ->afterStateHydrated(function (Get $get, Set $set) {
-                                self::updateTotals($get, $set);
-                            }),
-                    ]),
-                Section::make('Delivered')
-                    ->description('The client had paid and got his products')
-                    ->hiddenOn(['create', 'edit'])
-                    ->schema([
-                        Forms\Components\Toggle::make('delivered')
-                    ])
             ]);
     }
 
@@ -141,61 +191,107 @@ class OrderResource extends Resource
     {
         return $table
             ->columns([
-                TextColumn::make('user.name')
-                    ->label('Cashier')
-                    ->hidden(!auth()->user()->hasRole('super_admin')),
-                TextColumn::make('client_name')
-                    ->searchable(),
-                TextColumn::make('client_phone')
-                    ->searchable()
-                    ->toggleable(isToggledHiddenByDefault: true),
-                TextColumn::make('client_address')
-                    ->searchable()
-                    ->limit(20)
-                    ->toggleable(isToggledHiddenByDefault: true),
-                TextColumn::make('total')
+                Tables\Columns\TextColumn::make('id')
+                    ->label('Order')
+                    ->prefix('#')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('client_display_name')
+                    ->label('Client')
+                    ->state(fn (Order $record): string => $record->client?->name ?? 'Walk-in customer')
+                    ->description(fn (Order $record): ?string => $record->client?->phone)
+                    ->searchable(query: function (Builder $query, string $search): Builder {
+                        return $query->whereHas('client', function (Builder $clientQuery) use ($search): void {
+                            $clientQuery
+                                ->where('name', 'like', "%{$search}%")
+                                ->orWhere('phone', 'like', "%{$search}%")
+                                ->orWhere('address', 'like', "%{$search}%");
+                        });
+                    })
+                    ->sortable()
+                    ->placeholder('Walk-in customer'),
+                Tables\Columns\TextColumn::make('items_count')
+                    ->label('Items')
+                    ->state(fn (Order $record): int => $record->orderProducts()->count())
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('total')
                     ->money('XFA')
                     ->sortable(),
-                TextColumn::make('created_at')
-                    ->dateTime()
+                Tables\Columns\IconColumn::make('delivered')
+                    ->boolean()
+                    ->label('Delivered'),
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label('Cashier')
                     ->sortable()
-                    ->toggleable(isToggledHiddenByDefault: true),
-                TextColumn::make('updated_at')
+                    ->toggleable(isToggledHiddenByDefault: true)
+                    ->hidden(! auth()->user()?->hasRole('super_admin')),
+                Tables\Columns\TextColumn::make('created_at')
                     ->dateTime()
-                    ->sortable()
-                    ->toggleable(isToggledHiddenByDefault: true),
-                TextColumn::make('deleted_at')
-                    ->dateTime()
-                    ->sortable()
-                    ->toggleable(isToggledHiddenByDefault: true),
-                TextColumn::make('total')
-                    ->money('XFA')
-                    ->summarize(Sum::make()),
-                ToggleColumn::make('delivered'),
+                    ->sortable(),
             ])
             ->filters([
-                TrashedFilter::make(),
+                Tables\Filters\TrashedFilter::make(),
                 DateScopeFilter::make('created_at'),
             ])
             ->actions([
-                ViewAction::make(),
-                // EditAction::make(),
-                DeleteAction::make(),
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
             ])
             ->bulkActions([
-                BulkActionGroup::make([
-                    DeleteBulkAction::make(),
-                    ForceDeleteBulkAction::make(),
-                    RestoreBulkAction::make(),
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\ForceDeleteBulkAction::make(),
+                    Tables\Actions\RestoreBulkAction::make(),
                 ]),
-            ]);
+            ])
+            ->defaultSort('created_at', 'desc');
     }
 
-    public static function getRelations(): array
+    public static function infolist(Infolist $infolist): Infolist
     {
-        return [
-            //
-        ];
+        return $infolist
+            ->schema([
+                Infolists\Components\Section::make('Order details')
+                    ->schema([
+                        Infolists\Components\TextEntry::make('id')
+                            ->label('Order')
+                            ->prefix('#')
+                            ->weight('semibold'),
+                        Infolists\Components\TextEntry::make('client.name')
+                            ->label('Client')
+                            ->default('Walk-in customer'),
+                        Infolists\Components\TextEntry::make('client.phone')
+                            ->label('Phone')
+                            ->placeholder('No phone'),
+                        Infolists\Components\TextEntry::make('client.address')
+                            ->label('Address')
+                            ->placeholder('No address')
+                            ->columnSpanFull(),
+                        Infolists\Components\TextEntry::make('user.name')
+                            ->label('Cashier'),
+                        Infolists\Components\TextEntry::make('total')
+                            ->money('XFA'),
+                        Infolists\Components\IconEntry::make('delivered')
+                            ->boolean(),
+                        Infolists\Components\TextEntry::make('created_at')
+                            ->dateTime(),
+                    ])
+                    ->columns(3),
+                Infolists\Components\Section::make('Items')
+                    ->schema([
+                        Infolists\Components\RepeatableEntry::make('orderProducts')
+                            ->hiddenLabel()
+                            ->schema([
+                                Infolists\Components\TextEntry::make('product.name')
+                                    ->weight('semibold'),
+                                Infolists\Components\TextEntry::make('quantity'),
+                                Infolists\Components\TextEntry::make('price')
+                                    ->money('XFA')
+                                    ->label('Unit price'),
+                            ])
+                            ->columns(3),
+                    ]),
+            ]);
     }
 
     public static function getPages(): array
@@ -203,22 +299,22 @@ class OrderResource extends Resource
         return [
             'index' => Pages\ListOrders::route('/'),
             'create' => Pages\CreateOrder::route('/create'),
-            // 'view' => Pages\ViewOrder::route('/{record}'),
+            'view' => Pages\ViewOrder::route('/{record}'),
             'edit' => Pages\EditOrder::route('/{record}/edit'),
         ];
     }
 
     public static function getGlobalSearchResultTitle(Model $record): string
     {
-        return $record->client_name; // Show client name as title
+        return $record->client?->name ?? "Walk-in order #{$record->id}";
     }
 
     public static function getGloballySearchableAttributes(): array
     {
         return [
-            'client_name',
-            'client_phone',
-            'client_address',
+            'client.name',
+            'client.phone',
+            'client.address',
             'total',
         ];
     }
@@ -226,16 +322,16 @@ class OrderResource extends Resource
     public static function getGlobalSearchResultDetails(Model $record): array
     {
         return [
-            'Phone' => $record->client_phone,
-            'Address' => $record->client_address,
-            'Total' => $record->total,
+            'Phone' => $record->client?->phone ?: 'No phone',
+            'Address' => $record->client?->address ?: 'No address',
+            'Total' => self::formatMoney((float) $record->total),
             'Delivered' => $record->delivered ? 'Yes' : 'No',
         ];
     }
 
     public static function getGlobalSearchResultUrl(Model $record): string
     {
-        return OrderResource::getUrl('view', ['record' => $record]);
+        return static::getUrl('view', ['record' => $record]);
     }
 
     public static function getNavigationBadge(): ?string
@@ -243,6 +339,7 @@ class OrderResource extends Resource
         $undeliveredOrdersCount = static::getModel()::where('delivered', false)
             ->withoutTrashed()
             ->count();
+
         return $undeliveredOrdersCount > 0 ? (string) $undeliveredOrdersCount : null;
     }
 
@@ -253,35 +350,40 @@ class OrderResource extends Resource
 
     public static function getNavigationBadgeTooltip(): ?string
     {
-        return 'The number of undelivered orders';
+        return 'Undelivered orders';
     }
-
 
     public static function getEloquentQuery(): Builder
     {
         return parent::getEloquentQuery()
+            ->with([
+                'client',
+                'user',
+                'orderProducts.product',
+            ])
             ->withoutGlobalScopes([
                 SoftDeletingScope::class,
             ]);
     }
 
-    // / This function updates totals based on the selected products and quantities
     public static function updateTotals(Get $get, Set $set): void
     {
-        // Retrieve all selected products and remove empty rows
-        $selectedProducts = collect($get('orderProducts'))->filter(fn($item) => !empty($item['product_id']) && !empty($item['quantity']));
+        $selectedProducts = collect($get('orderProducts'))
+            ->filter(fn ($item) => filled($item['product_id'] ?? null) && filled($item['quantity'] ?? null));
 
-        // Retrieve prices for all selected products
-        $prices = Product::find($selectedProducts->pluck('product_id'))->pluck('price', 'id');
+        $prices = Product::query()
+            ->whereIn('id', $selectedProducts->pluck('product_id'))
+            ->pluck('price', 'id');
 
-        // Calculate subtotal based on the selected products and quantities
-        $subtotal = $selectedProducts->reduce(function ($subtotal, $product) use ($prices) {
-            return $subtotal + ($prices[$product['product_id']] * $product['quantity']);
+        $total = $selectedProducts->reduce(function (float $subtotal, array $product) use ($prices): float {
+            return $subtotal + (((float) ($prices[$product['product_id']] ?? 0)) * ((int) $product['quantity']));
         }, 0);
 
-        // Update the state with the new values
-        // $set('subtotal', number_format($subtotal, 2, '.', ''));
-        $set('total', number_format($subtotal, 2, '.', ''));
-        // $set('total', number_format($subtotal + ($subtotal * ($get('taxes') / 100)), 2, '.', ''));
+        $set('total', number_format($total, 2, '.', ''));
+    }
+
+    public static function formatMoney(float $amount): string
+    {
+        return number_format($amount, 2).' XFA';
     }
 }

--- a/app/Filament/Resources/OrderResource/Pages/CreateOrder.php
+++ b/app/Filament/Resources/OrderResource/Pages/CreateOrder.php
@@ -2,62 +2,46 @@
 
 namespace App\Filament\Resources\OrderResource\Pages;
 
-use App\Models\User;
-use App\Models\Product;
-use App\Mail\LowStockAlert;
-use Illuminate\Support\Facades\Mail;
-use Filament\Notifications\Notification;
 use App\Filament\Resources\OrderResource;
+use App\Mail\LowStockAlert;
+use App\Models\Client;
+use App\Models\Product;
+use App\Models\User;
+use App\Support\Orders\OrderStockManager;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Support\Facades\Mail;
 
 class CreateOrder extends CreateRecord
 {
     protected static string $resource = OrderResource::class;
 
+    protected static string $view = 'filament.resources.order-resource.pages.create-order';
+
     protected function getCreatedNotification(): ?Notification
     {
         return Notification::make()
             ->success()
-            ->title("Order created")
-            ->body("The Order has been created successfully.")
+            ->title('Order created')
+            ->body('The Order has been created successfully.')
             ->icon('heroicon-o-document-text')
             ->color('success');
     }
 
     protected function beforeCreate(): void
     {
-        foreach ($this->data['orderProducts'] as $order) {
-            $product = Product::find($order['product_id']);
+        $errorMessage = OrderStockManager::validate($this->data['orderProducts'] ?? []);
 
-            if (!$product) {
-                Notification::make()
-                    ->error()
-                    ->title("Product not found")
-                    ->body('The product with ID ' . $order['product_id'] . ' does not exist.')
-                    ->persistent()
-                    ->send();
+        if ($errorMessage) {
+            Notification::make()
+                ->warning()
+                ->title('Unable to complete this sale')
+                ->body($errorMessage)
+                ->persistent()
+                ->send();
 
-                $this->halt();
-            }
-
-            if ($product->quantity < $order['quantity']) {
-                Notification::make()
-                    ->warning()
-                    ->title("Insufficient stock")
-                    ->body('The quantity needed for the product ' . $product->name . ' is not available. Available quantity is: ' . $product->quantity)
-                    ->persistent()
-                    ->send();
-
-                $this->halt();
-            }
-        }
-
-        foreach ($this->data['orderProducts'] as $order) {
-            $product = Product::find($order['product_id']);
-
-            if ($product) {
-                $product->decrement('quantity', $order['quantity']);
-            }
+            $this->halt();
         }
     }
 
@@ -70,6 +54,8 @@ class CreateOrder extends CreateRecord
 
     protected function afterCreate(): void
     {
+        OrderStockManager::sync($this->data['orderProducts'] ?? []);
+
         $lowStockProducts = Product::where('quantity', '<=', 10)->get(['name', 'quantity']);
 
         if ($lowStockProducts->isNotEmpty()) {
@@ -83,5 +69,65 @@ class CreateOrder extends CreateRecord
 
             Mail::send(new LowStockAlert($emailData));
         }
+    }
+
+    protected function getCreateFormAction(): Action
+    {
+        return parent::getCreateFormAction()
+            ->label('Complete sale');
+    }
+
+    protected function getCreateAnotherFormAction(): Action
+    {
+        return parent::getCreateAnotherFormAction()
+            ->label('Save and start next sale');
+    }
+
+    public function getCartItems(): array
+    {
+        $items = collect(data_get($this->data, 'orderProducts', []))
+            ->filter(fn (array $item): bool => filled($item['product_id'] ?? null))
+            ->values();
+
+        $products = Product::query()
+            ->whereIn('id', $items->pluck('product_id'))
+            ->get()
+            ->keyBy('id');
+
+        return $items
+            ->map(function (array $item) use ($products): array {
+                $product = $products->get($item['product_id']);
+                $quantity = (int) ($item['quantity'] ?? 0);
+                $price = (float) ($item['price'] ?? $product?->price ?? 0);
+
+                return [
+                    'name' => $product?->name ?? 'Unavailable product',
+                    'quantity' => $quantity,
+                    'price' => $price,
+                    'line_total' => $quantity * $price,
+                ];
+            })
+            ->all();
+    }
+
+    public function getSelectedClient(): ?Client
+    {
+        $clientId = data_get($this->data, 'client_id');
+
+        if (! $clientId) {
+            return null;
+        }
+
+        return Client::find($clientId);
+    }
+
+    public function getCartTotal(): float
+    {
+        return collect($this->getCartItems())->sum('line_total');
+    }
+
+    public function getCartQuantity(): int
+    {
+        return (int) collect($this->getCartItems())->sum('quantity');
     }
 }

--- a/app/Filament/Resources/OrderResource/Pages/EditOrder.php
+++ b/app/Filament/Resources/OrderResource/Pages/EditOrder.php
@@ -2,18 +2,24 @@
 
 namespace App\Filament\Resources\OrderResource\Pages;
 
-use App\Models\User;
-use Filament\Actions;
-use App\Models\Product;
+use App\Filament\Resources\OrderResource;
 use App\Mail\LowStockAlert;
-use Illuminate\Support\Facades\Mail;
+use App\Models\Product;
+use App\Models\User;
+use App\Support\Orders\OrderStockManager;
+use Filament\Actions;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
-use App\Filament\Resources\OrderResource;
+use Illuminate\Support\Facades\Mail;
 
 class EditOrder extends EditRecord
 {
     protected static string $resource = OrderResource::class;
+
+    /**
+     * @var array<int, int>
+     */
+    protected array $originalQuantities = [];
 
     protected function getHeaderActions(): array
     {
@@ -27,10 +33,12 @@ class EditOrder extends EditRecord
 
     protected function beforeSave(): void
     {
-        if ($this->data['delivered']) {
+        $this->originalQuantities = OrderStockManager::originalQuantities($this->record);
+
+        if ($this->record->delivered) {
             Notification::make()
                 ->warning()
-                ->title("Order cannot be edited")
+                ->title('Order cannot be edited')
                 ->body('The order has already been delivered and cannot be edited.')
                 ->persistent()
                 ->send();
@@ -38,57 +46,24 @@ class EditOrder extends EditRecord
             $this->halt();
         }
 
-        foreach ($this->data['orderProducts'] as $order) {
-            $product = Product::find($order['product_id']);
+        $errorMessage = OrderStockManager::validate($this->data['orderProducts'] ?? [], $this->originalQuantities);
 
-            if (!$product) {
-                Notification::make()
-                    ->error()
-                    ->title("Product not found")
-                    ->body('The product with ID ' . $order['product_id'] . ' does not exist.')
-                    ->persistent()
-                    ->send();
+        if ($errorMessage) {
+            Notification::make()
+                ->warning()
+                ->title('Unable to update this order')
+                ->body($errorMessage)
+                ->persistent()
+                ->send();
 
-                $this->halt();
-            }
-
-            $originalOrder = $this->record->orderProducts->firstWhere('product_id', $order['product_id']);
-            $originalQuantity = $originalOrder ? $originalOrder->quantity : 0;
-
-            $availableQuantity = $product->quantity + $originalQuantity;
-
-            if ($availableQuantity < $order['quantity']) {
-                Notification::make()
-                    ->warning()
-                    ->title("Insufficient stock")
-                    ->body('The quantity needed for the product ' . $product->name . ' is not available. Available quantity is: ' . $availableQuantity)
-                    ->persistent()
-                    ->send();
-
-                $this->halt();
-            }
-        }
-
-        foreach ($this->data['orderProducts'] as $order) {
-            $product = Product::find($order['product_id']);
-
-            if ($product) {
-                $originalOrder = $this->record->orderProducts->firstWhere('product_id', $order['product_id']);
-                $originalQuantity = $originalOrder ? $originalOrder->quantity : 0;
-
-                if ($order['quantity'] > $originalQuantity) {
-                    // Decrease stock if the new quantity is greater than the original
-                    $product->decrement('quantity', $order['quantity'] - $originalQuantity);
-                } elseif ($order['quantity'] < $originalQuantity) {
-                    // Increase stock if the new quantity is less than the original
-                    $product->increment('quantity', $originalQuantity - $order['quantity']);
-                }
-            }
+            $this->halt();
         }
     }
 
     protected function afterSave(): void
     {
+        OrderStockManager::sync($this->data['orderProducts'] ?? [], $this->originalQuantities);
+
         $lowStockProducts = Product::where('quantity', '<=', 10)->get(['name', 'quantity']);
 
         if ($lowStockProducts->isNotEmpty()) {

--- a/app/Filament/Resources/OrderResource/Pages/ListOrders.php
+++ b/app/Filament/Resources/OrderResource/Pages/ListOrders.php
@@ -3,7 +3,6 @@
 namespace App\Filament\Resources\OrderResource\Pages;
 
 use App\Models\Order;
-use Filament\Actions;
 use Filament\Resources\Components\Tab;
 use App\Filament\Resources\OrderResource;
 use Filament\Resources\Pages\ListRecords;
@@ -15,9 +14,7 @@ class ListOrders extends ListRecords
 
     protected function getHeaderActions(): array
     {
-        return [
-            Actions\CreateAction::make()
-        ];
+        return [];
     }
 
     public function getTabs(): array

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Client extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'name',
+        'phone',
+        'address',
+        'notes',
+    ];
+
+    public function orders(): HasMany
+    {
+        return $this->hasMany(Order::class);
+    }
+}

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -2,23 +2,20 @@
 
 namespace App\Models;
 
-use App\Models\OrderProduct;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use LaracraftTech\LaravelDateScopes\DateScopes;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Order extends Model
 {
-    use HasFactory, SoftDeletes, DateScopes;
+    use DateScopes, HasFactory, SoftDeletes;
 
     protected $fillable = [
         'user_id',
-        'client_name',
-        'client_phone',
-        'client_address',
+        'client_id',
         'total',
         'delivered',
     ];
@@ -28,101 +25,13 @@ class Order extends Model
         return $this->belongsTo(User::class);
     }
 
-    // public function products()
-    // {
-    //     return $this->belongsToMany(Product::class)
-    //         ->withPivot('quantity', 'price')
-    //         ->withTimestamps();
-    // }
+    public function client(): BelongsTo
+    {
+        return $this->belongsTo(Client::class);
+    }
 
     public function orderProducts(): HasMany
     {
         return $this->hasMany(OrderProduct::class);
     }
-
 }
-// query by SECONDS
-Order::ofJustNow(); // query Orders created just now
-Order::ofLastSecond(); // query Orders created during the last second
-Order::ofLast15Seconds(); // query Orders created during the last 15 seconds
-Order::ofLast30Seconds(); // query Orders created during the last 30 seconds
-Order::ofLast45Seconds(); // query Orders created during the last 45 seconds
-Order::ofLast60Seconds(); // query Orders created during the last 60 seconds
-Order::ofLastSeconds(120); // query Orders created during the last N seconds
-
-// query by MINUTES
-Order::ofLastMinute(); // query Orders created during the last minute
-Order::ofLast15Minutes(); // query Orders created during the last 15 minutes
-Order::ofLast30Minutes(); // query Orders created during the last 30 minutes
-Order::ofLast45Minutes(); // query Orders created during the last 45 minutes
-Order::ofLast60Minutes(); // query Orders created during the last 60 minutes
-Order::ofLastMinutes(120); // query Orders created during the last N minutes
-
-// query by HOURS
-Order::ofLastHour(); // query Orders created during the last hour
-Order::ofLast6Hours(); // query Orders created during the last 6 hours
-Order::ofLast12Hours(); // query Orders created during the last 12 hours
-Order::ofLast18Hours(); // query Orders created during the last 18 hours
-Order::ofLast24Hours(); // query Orders created during the last 24 hours
-Order::ofLastHours(48); // query Orders created during the last N hours
-
-// query by DAYS
-Order::ofToday(); // query Orders created today
-Order::ofYesterday(); // query Orders created yesterday
-Order::ofLast7Days(); // query Orders created during the last 7 days
-Order::ofLast21Days(); // query Orders created during the last 21 days
-Order::ofLast30Days(); // query Orders created during the last 30 days
-Order::ofLastDays(60); // query Orders created during the last N days
-
-// query by WEEKS
-Order::ofLastWeek(); // query Orders created during the last week
-Order::ofLast2Weeks(); // query Orders created during the last 2 weeks
-Order::ofLast3Weeks(); // query Orders created during the last 3 weeks
-Order::ofLast4Weeks(); // query Orders created during the last 4 weeks
-Order::ofLastWeeks(8); // query Orders created during the last N weeks
-
-// query by MONTHS
-Order::ofLastMonth(); // query Orders created during the last month
-Order::ofLast3Months(); // query Orders created during the last 3 months
-Order::ofLast6Months(); // query Orders created during the last 6 months
-Order::ofLast9Months(); // query Orders created during the last 9 months
-Order::ofLast12Months(); // query Orders created during the last 12 months
-Order::ofLastMonths(24); // query Orders created during the last N months
-
-// query by QUARTERS
-Order::ofLastQuarter(); // query Orders created during the last quarter
-Order::ofLast2Quarters(); // query Orders created during the last 2 quarters
-Order::ofLast3Quarters(); // query Orders created during the last 3 quarters
-Order::ofLast4Quarters(); // query Orders created during the last 4 quarters
-Order::ofLastQuarters(8); // query Orders created during the last N quarters
-
-// query by YEARS
-Order::ofLastYear(); // query Orders created during the last year
-Order::ofLastYears(2); // query Orders created during the last N years
-
-// query by DECADES
-Order::ofLastDecade(); // query Orders created during the last decade
-Order::ofLastDecades(2); // query Orders created during the last N decades
-
-// query by toNow/toDate
-Order::secondToNow(); // query Orders created during the start of the current second till now (equivalent of just now)
-Order::minuteToNow(); // query Orders created during the start of the current minute till now
-Order::hourToNow(); // query Orders created during the start of the current hour till now
-Order::dayToNow(); // query Orders created during the start of the current day till now
-Order::weekToDate(); // query Orders created during the start of the current week till now
-Order::monthToDate(); // query Orders created during the start of the current month till now
-Order::quarterToDate(); // query Orders created during the start of the current quarter till now
-Order::yearToDate(); // query Orders created during the start of the current year till now
-Order::decadeToDate(); // query Orders created during the start of the current decade till now
-Order::centuryToDate(); // query Orders created during the start of the current century till now
-Order::millenniumToDate(); // query Orders created during the start of the current millennium till now
-
-
-// query order created today
-Order::ofToday();
- // query order created during the last week
-Order::ofLastWeek();
- // query order created during the start of the current month till now
-Order::monthToDate();
- // query order created during the last year, start from 2020
-Order::ofLastYear(startFrom: '2020-01-01');

--- a/app/Models/OrderProduct.php
+++ b/app/Models/OrderProduct.php
@@ -1,13 +1,15 @@
 <?php
+
 namespace App\Models;
 
-use App\Models\Order;
-use App\Models\Product;
-use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class OrderProduct extends Pivot
 {
+    use SoftDeletes;
+
     public function order(): BelongsTo
     {
         return $this->belongsTo(Order::class);

--- a/app/Policies/ClientPolicy.php
+++ b/app/Policies/ClientPolicy.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Client;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ClientPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return $user->can('view_any_client');
+    }
+
+    public function view(User $user, Client $client): bool
+    {
+        return $user->can('view_client');
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->can('create_client');
+    }
+
+    public function update(User $user, Client $client): bool
+    {
+        return $user->can('update_client');
+    }
+
+    public function delete(User $user, Client $client): bool
+    {
+        return $user->can('delete_client');
+    }
+
+    public function deleteAny(User $user): bool
+    {
+        return $user->can('delete_any_client');
+    }
+
+    public function forceDelete(User $user, Client $client): bool
+    {
+        return $user->can('force_delete_client');
+    }
+
+    public function forceDeleteAny(User $user): bool
+    {
+        return $user->can('force_delete_any_client');
+    }
+
+    public function restore(User $user, Client $client): bool
+    {
+        return $user->can('restore_client');
+    }
+
+    public function restoreAny(User $user): bool
+    {
+        return $user->can('restore_any_client');
+    }
+
+    public function replicate(User $user, Client $client): bool
+    {
+        return $user->can('replicate_client');
+    }
+
+    public function reorder(User $user): bool
+    {
+        return $user->can('reorder_client');
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,25 +2,23 @@
 
 namespace App\Providers\Filament;
 
-use Filament\Pages;
-use Filament\Pages\Dashboard;
-use Filament\Panel;
-use Filament\Widgets;
-use Filament\PanelProvider;
-use Filament\Support\Colors\Color;
-use Filament\Http\Middleware\Authenticate;
-use Illuminate\Session\Middleware\StartSession;
-use Illuminate\Cookie\Middleware\EncryptCookies;
-use Illuminate\Routing\Middleware\SubstituteBindings;
-use Illuminate\Session\Middleware\AuthenticateSession;
-use Illuminate\View\Middleware\ShareErrorsFromSession;
-use Filament\Http\Middleware\DisableBladeIconComponents;
-use Swis\Filament\Backgrounds\FilamentBackgroundsPlugin;
-use Filament\Http\Middleware\DispatchServingFilamentEvent;
-use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
-use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use App\Filament\Resources\OrderResource\Widgets\OrdersChart;
 use App\Filament\Resources\UserResource\Widgets\UserOverview;
+use Filament\Http\Middleware\Authenticate;
+use Filament\Http\Middleware\DisableBladeIconComponents;
+use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Navigation\NavigationGroup;
+use Filament\Pages;
+use Filament\Panel;
+use Filament\PanelProvider;
+use Filament\Support\Colors\Color;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 class AdminPanelProvider extends PanelProvider
 {
@@ -38,10 +36,12 @@ class AdminPanelProvider extends PanelProvider
             ->colors([
                 'primary' => Color::Cyan,
             ])
+            ->sidebarCollapsibleOnDesktop()
+            ->viteTheme('resources/css/filament/admin/theme.css')
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
             ->pages([
-                Pages\Dashboard::class
+                Pages\Dashboard::class,
             ])
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
             ->widgets([
@@ -66,8 +66,18 @@ class AdminPanelProvider extends PanelProvider
                 \BezhanSalleh\FilamentShield\FilamentShieldPlugin::make(),
             ])
             ->navigationGroups([
-                'Stocks Management',
-                'Users Management'
+                NavigationGroup::make()
+                    ->label('Sales Management')
+                    ->icon('heroicon-o-shopping-bag')
+                    ->collapsed(),
+                NavigationGroup::make()
+                    ->label('Stocks Management')
+                    ->icon('heroicon-o-cube')
+                    ->collapsed(),
+                NavigationGroup::make()
+                    ->label('Users Management')
+                    ->icon('heroicon-o-users')
+                    ->collapsed(),
             ])
             ->globalSearchKeyBindings(['command+k', 'ctrl+k'])
             ->brandLogo(asset('images/logo.png'))

--- a/app/Support/Orders/OrderStockManager.php
+++ b/app/Support/Orders/OrderStockManager.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Support\Orders;
+
+use App\Models\Order;
+use App\Models\Product;
+use Illuminate\Support\Collection;
+
+class OrderStockManager
+{
+    public static function validate(array $items, ?array $originalQuantities = null): ?string
+    {
+        $submittedQuantities = self::submittedQuantities($items);
+        $originalQuantities ??= [];
+
+        foreach ($submittedQuantities as $productId => $quantity) {
+            $product = Product::find($productId);
+
+            if (! $product) {
+                return "The selected product #{$productId} no longer exists.";
+            }
+
+            $availableQuantity = $product->quantity + ($originalQuantities[$productId] ?? 0);
+
+            if ($availableQuantity < $quantity) {
+                return "Insufficient stock for {$product->name}. Available quantity is {$availableQuantity}.";
+            }
+        }
+
+        return null;
+    }
+
+    public static function sync(array $items, ?array $originalQuantities = null): void
+    {
+        $submittedQuantities = self::submittedQuantities($items);
+        $originalQuantities ??= [];
+        $productIds = collect(array_keys($submittedQuantities))
+            ->merge(array_keys($originalQuantities))
+            ->unique()
+            ->values();
+
+        Product::whereIn('id', $productIds)
+            ->get()
+            ->each(function (Product $product) use ($submittedQuantities, $originalQuantities): void {
+                $newQuantity = $submittedQuantities[$product->id] ?? 0;
+                $oldQuantity = $originalQuantities[$product->id] ?? 0;
+                $difference = $oldQuantity - $newQuantity;
+
+                if ($difference > 0) {
+                    $product->increment('quantity', $difference);
+                }
+
+                if ($difference < 0) {
+                    $product->decrement('quantity', abs($difference));
+                }
+            });
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    protected static function submittedQuantities(array $items): array
+    {
+        return collect($items)
+            ->filter(fn (array $item): bool => filled($item['product_id'] ?? null) && filled($item['quantity'] ?? null))
+            ->mapWithKeys(fn (array $item): array => [
+                (int) $item['product_id'] => (int) $item['quantity'],
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public static function originalQuantities(?Order $order): array
+    {
+        if (! $order) {
+            return [];
+        }
+
+        return $order->orderProducts()
+            ->get(['product_id', 'quantity'])
+            ->mapWithKeys(fn ($item): array => [(int) $item->product_id => (int) $item->quantity])
+            ->all();
+    }
+}

--- a/config/access.php
+++ b/config/access.php
@@ -1,0 +1,36 @@
+<?php
+
+$resourcePermissions = static fn (string $resource): array => [
+    "view_{$resource}",
+    "view_any_{$resource}",
+    "create_{$resource}",
+    "update_{$resource}",
+    "restore_{$resource}",
+    "restore_any_{$resource}",
+    "replicate_{$resource}",
+    "reorder_{$resource}",
+    "delete_{$resource}",
+    "delete_any_{$resource}",
+    "force_delete_{$resource}",
+    "force_delete_any_{$resource}",
+];
+
+return [
+    'roles' => [
+        [
+            'name' => 'super_admin',
+            'guard_name' => 'web',
+            'permissions' => array_merge(
+                $resourcePermissions('product'),
+                $resourcePermissions('product::category'),
+                $resourcePermissions('product::supplier'),
+                $resourcePermissions('order'),
+                $resourcePermissions('client'),
+                $resourcePermissions('user'),
+                ['page_Pos']
+            ),
+        ],
+    ],
+
+    'direct_permissions' => [],
+];

--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Client;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Client>
+ */
+class ClientFactory extends Factory
+{
+    protected $model = Client::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->name(),
+            'phone' => $this->faker->optional()->phoneNumber(),
+            'address' => $this->faker->optional()->address(),
+            'notes' => $this->faker->optional()->sentence(),
+        ];
+    }
+}

--- a/database/factories/OrderFactory.php
+++ b/database/factories/OrderFactory.php
@@ -2,8 +2,9 @@
 
 namespace Database\Factories;
 
-use Illuminate\Support\Carbon;
+use App\Models\Client;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Order>
@@ -18,10 +19,8 @@ class OrderFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id' => $this->faker->numberBetween(1, 3),
-            'client_name' => $this->faker->name(),
-            'client_phone' => $this->faker->phoneNumber(),
-            'client_address' => $this->faker->address(),
+            'user_id' => 1,
+            'client_id' => $this->faker->boolean(80) ? Client::factory() : null,
             'total' => $this->faker->randomFloat(2, 1, 1000),
             'delivered' => $this->faker->boolean(),
             'created_at' => Carbon::now()->startOfYear()->addDays(rand(0, 364)), // Random date within the current year

--- a/database/migrations/2024_02_19_085020_create_orders_table.php
+++ b/database/migrations/2024_02_19_085020_create_orders_table.php
@@ -14,9 +14,9 @@ return new class extends Migration
         Schema::create('orders', function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('user_id');
-            $table->string("client_name");
-            $table->string("client_phone");
-            $table->string("client_address");
+            $table->string('client_name');
+            $table->string('client_phone');
+            $table->string('client_address');
             $table->double('total', 100, 2);
             $table->boolean('delivered')->default(false);
             $table->timestamps();

--- a/database/migrations/2026_03_29_120000_create_clients_table_and_move_order_clients.php
+++ b/database/migrations/2026_03_29_120000_create_clients_table_and_move_order_clients.php
@@ -1,0 +1,123 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('clients', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('phone')->nullable();
+            $table->string('address')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::table('orders', function (Blueprint $table) {
+            $table->foreignId('client_id')
+                ->nullable()
+                ->after('user_id')
+                ->constrained('clients')
+                ->nullOnDelete();
+        });
+
+        $clientIdsBySignature = [];
+
+        DB::table('orders')
+            ->select(['id', 'client_name', 'client_phone', 'client_address'])
+            ->orderBy('id')
+            ->chunkById(100, function ($orders) use (&$clientIdsBySignature): void {
+                foreach ($orders as $order) {
+                    if (blank($order->client_name) && blank($order->client_phone) && blank($order->client_address)) {
+                        continue;
+                    }
+
+                    $signature = md5(json_encode([
+                        $order->client_name,
+                        $order->client_phone,
+                        $order->client_address,
+                    ]));
+
+                    if (! isset($clientIdsBySignature[$signature])) {
+                        $clientIdsBySignature[$signature] = DB::table('clients')
+                            ->where('name', $order->client_name)
+                            ->where(function ($query) use ($order): void {
+                                $order->client_phone === null
+                                    ? $query->whereNull('phone')
+                                    : $query->where('phone', $order->client_phone);
+                            })
+                            ->where(function ($query) use ($order): void {
+                                $order->client_address === null
+                                    ? $query->whereNull('address')
+                                    : $query->where('address', $order->client_address);
+                            })
+                            ->value('id');
+                    }
+
+                    if (! $clientIdsBySignature[$signature]) {
+                        $clientIdsBySignature[$signature] = DB::table('clients')->insertGetId([
+                            'name' => $order->client_name ?: 'Walk-in customer',
+                            'phone' => $order->client_phone,
+                            'address' => $order->client_address,
+                            'created_at' => now(),
+                            'updated_at' => now(),
+                        ]);
+                    }
+
+                    DB::table('orders')
+                        ->where('id', $order->id)
+                        ->update(['client_id' => $clientIdsBySignature[$signature]]);
+                }
+            });
+
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropColumn([
+                'client_name',
+                'client_phone',
+                'client_address',
+            ]);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->string('client_name')->nullable()->after('user_id');
+            $table->string('client_phone')->nullable()->after('client_name');
+            $table->string('client_address')->nullable()->after('client_phone');
+        });
+
+        DB::table('orders')
+            ->leftJoin('clients', 'clients.id', '=', 'orders.client_id')
+            ->select([
+                'orders.id as order_id',
+                'clients.name',
+                'clients.phone',
+                'clients.address',
+            ])
+            ->orderBy('orders.id')
+            ->chunkById(100, function ($orders): void {
+                foreach ($orders as $order) {
+                    DB::table('orders')
+                        ->where('id', $order->order_id)
+                        ->update([
+                            'client_name' => $order->name,
+                            'client_phone' => $order->phone,
+                            'client_address' => $order->address,
+                        ]);
+                }
+            }, 'orders.id', 'order_id');
+
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('client_id');
+        });
+
+        Schema::dropIfExists('clients');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,11 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\User;
-use App\Models\Order;
-use App\Models\Product;
-use Illuminate\Support\Str;
-use App\Models\ProductCategory;
-use App\Models\ProductSupplier;
+use Database\Factories\UserFactory;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -18,43 +14,41 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         // Create users
-        // User::factory(2)->create();
 
-        // Create product categories with real values
-        $categories = [
-            ['title' => 'Electronics', 'slug' => 'electronics'],
-            ['title' => 'Furniture', 'slug' => 'furniture'],
-            ['title' => 'Clothing', 'slug' => 'clothing'],
-            ['title' => 'Books', 'slug' => 'books'],
-            ['title' => 'Toys', 'slug' => 'toys'],
-        ];
-        foreach ($categories as $category) {
-            ProductCategory::create($category);
-        }
 
-        // Create product suppliers with real values
-        $suppliers = [
-            ['name' => 'Supplier A', 'email' => 'supplierA@example.com', 'phone' => '1234567890', 'category_id' => 1],
-            ['name' => 'Supplier B', 'email' => 'supplierB@example.com', 'phone' => '0987654321', 'category_id' => 2],
-            ['name' => 'Supplier C', 'email' => 'supplierC@example.com', 'phone' => '1122334455', 'category_id' => 3],
-        ];
-        foreach ($suppliers as $supplier) {
-            ProductSupplier::create($supplier);
-        }
+        $user = $this->createUser();
 
-        // Create products with real values
-        $products = [
-            ['name' => 'Laptop', 'slug' => Str::slug("Laptop"), 'price' => 1000, 'quantity' => 50, 'product_categories_id' => 1, 'product_suppliers_id' => 1, 'image' => 'laptop.jpg'],
-            ['name' => 'Sofa', 'slug' => Str::slug("Sofa"), 'price' => 500, 'quantity' => 20, 'product_categories_id' => 2, 'product_suppliers_id' => 2, 'image' => 'sofa.jpg'],
-            ['name' => 'T-Shirt', 'slug' => Str::slug("T-Shirt"), 'price' => 20, 'quantity' => 100, 'product_categories_id' => 3, 'product_suppliers_id' => 3, 'image' => 'tshirt.jpg'],
-            ['name' => 'Novel', 'slug' => Str::slug("Novel"), 'price' => 15, 'quantity' => 40, 'product_categories_id' => 4, 'product_suppliers_id' => 1, 'image' => 'novel.jpg'],
-            ['name' => 'Action Figure', 'slug' => Str::slug("Action Figure"), 'price' => 25, 'quantity' => 30, 'product_categories_id' => 5, 'product_suppliers_id' => 2, 'image' => 'action_figure.jpg'],
-        ];
-        foreach ($products as $product) {
-            Product::create($product);
-        }
+        $this->call([
+            ShieldSeeder::class,
+            ProductCategorySeeder::class,
+            ProductSupplierSeeder::class,
+            ProductSeeder::class,
+            OrderSeeder::class,
+        ]);
 
-        // Generate orders using factories
-        $orders = Order::factory(873)->create();
+
+        $this->assignRole($user);
+
+
+    }
+
+    public function createUser(): User
+    {
+       return User::create([
+            'name' => 'Super Admin',
+            'email' => 'admin@admin.site',
+            'email_verified_at' => now(),
+            'password' => 'password',
+        ]);
+
+    }
+
+    /**
+     * @param $user
+     * @return void
+     */
+    public function assignRole($user): void
+    {
+        $user->assignRole('super_admin');
     }
 }

--- a/database/seeders/OrderSeeder.php
+++ b/database/seeders/OrderSeeder.php
@@ -3,7 +3,6 @@
 namespace Database\Seeders;
 
 use App\Models\Order;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class OrderSeeder extends Seeder
@@ -13,7 +12,7 @@ class OrderSeeder extends Seeder
      */
     public function run(): void
     {
-        Order::truncate()->cascade();
-        Order::factory(40)->create();
+        // Generate orders using factories
+        $orders = Order::factory(873)->create();
     }
 }

--- a/database/seeders/ProductCategorySeeder.php
+++ b/database/seeders/ProductCategorySeeder.php
@@ -3,7 +3,6 @@
 namespace Database\Seeders;
 
 use App\Models\ProductCategory;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class ProductCategorySeeder extends Seeder
@@ -13,7 +12,16 @@ class ProductCategorySeeder extends Seeder
      */
     public function run(): void
     {
-        ProductCategory::truncate()->cascade();
-        ProductCategory::factory(10)->create();
+        // Create product categories with real values
+        $categories = [
+            ['title' => 'Electronics', 'slug' => 'electronics'],
+            ['title' => 'Furniture', 'slug' => 'furniture'],
+            ['title' => 'Clothing', 'slug' => 'clothing'],
+            ['title' => 'Books', 'slug' => 'books'],
+            ['title' => 'Toys', 'slug' => 'toys'],
+        ];
+        foreach ($categories as $category) {
+            ProductCategory::create($category);
+        }
     }
 }

--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -3,8 +3,8 @@
 namespace Database\Seeders;
 
 use App\Models\Product;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
 
 class ProductSeeder extends Seeder
 {
@@ -13,7 +13,16 @@ class ProductSeeder extends Seeder
      */
     public function run(): void
     {
-        Product::truncate()->cascade();
-        Product::factory(10)->create();
+        // Create products with real values
+        $products = [
+            ['name' => 'Laptop', 'slug' => Str::slug('Laptop'), 'price' => 1000, 'quantity' => 50, 'product_categories_id' => 1, 'product_suppliers_id' => 1, 'image' => 'laptop.jpg'],
+            ['name' => 'Sofa', 'slug' => Str::slug('Sofa'), 'price' => 500, 'quantity' => 20, 'product_categories_id' => 2, 'product_suppliers_id' => 2, 'image' => 'sofa.jpg'],
+            ['name' => 'T-Shirt', 'slug' => Str::slug('T-Shirt'), 'price' => 20, 'quantity' => 100, 'product_categories_id' => 3, 'product_suppliers_id' => 3, 'image' => 'tshirt.jpg'],
+            ['name' => 'Novel', 'slug' => Str::slug('Novel'), 'price' => 15, 'quantity' => 40, 'product_categories_id' => 4, 'product_suppliers_id' => 1, 'image' => 'novel.jpg'],
+            ['name' => 'Action Figure', 'slug' => Str::slug('Action Figure'), 'price' => 25, 'quantity' => 30, 'product_categories_id' => 5, 'product_suppliers_id' => 2, 'image' => 'action_figure.jpg'],
+        ];
+        foreach ($products as $product) {
+            Product::create($product);
+        }
     }
 }

--- a/database/seeders/ProductSupplierSeeder.php
+++ b/database/seeders/ProductSupplierSeeder.php
@@ -3,7 +3,6 @@
 namespace Database\Seeders;
 
 use App\Models\ProductSupplier;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class ProductSupplierSeeder extends Seeder
@@ -13,7 +12,14 @@ class ProductSupplierSeeder extends Seeder
      */
     public function run(): void
     {
-        ProductSupplier::truncate()->cascade();
-        ProductSupplier::factory(5)->create();
+        // Create product suppliers with real values
+        $suppliers = [
+            ['name' => 'Supplier A', 'email' => 'supplierA@example.com', 'phone' => '1234567890', 'category_id' => 1],
+            ['name' => 'Supplier B', 'email' => 'supplierB@example.com', 'phone' => '0987654321', 'category_id' => 2],
+            ['name' => 'Supplier C', 'email' => 'supplierC@example.com', 'phone' => '1122334455', 'category_id' => 3],
+        ];
+        foreach ($suppliers as $supplier) {
+            ProductSupplier::create($supplier);
+        }
     }
 }

--- a/database/seeders/ShieldSeeder.php
+++ b/database/seeders/ShieldSeeder.php
@@ -2,8 +2,8 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
 use BezhanSalleh\FilamentShield\Support\Utils;
+use Illuminate\Database\Seeder;
 use Spatie\Permission\PermissionRegistrar;
 
 class ShieldSeeder extends Seeder
@@ -12,8 +12,8 @@ class ShieldSeeder extends Seeder
     {
         app()[PermissionRegistrar::class]->forgetCachedPermissions();
 
-        $rolesWithPermissions = '[{"name":"super_admin","guard_name":"web","permissions":["view_product","view_any_product","create_product","update_product","restore_product","restore_any_product","replicate_product","reorder_product","delete_product","delete_any_product","force_delete_product","force_delete_any_product","view_product::category","view_any_product::category","create_product::category","update_product::category","restore_product::category","restore_any_product::category","replicate_product::category","reorder_product::category","delete_product::category","delete_any_product::category","force_delete_product::category","force_delete_any_product::category","view_product::supplier","view_any_product::supplier","create_product::supplier","update_product::supplier","restore_product::supplier","restore_any_product::supplier","replicate_product::supplier","reorder_product::supplier","delete_product::supplier","delete_any_product::supplier","force_delete_product::supplier","force_delete_any_product::supplier","view_user","view_any_user","create_user","update_user","restore_user","restore_any_user","replicate_user","reorder_user","delete_user","delete_any_user","force_delete_user","force_delete_any_user"]}]';
-        $directPermissions = '[]';
+        $rolesWithPermissions = config('access.roles', []);
+        $directPermissions = config('access.direct_permissions', []);
 
         static::makeRolesWithPermissions($rolesWithPermissions);
         static::makeDirectPermissions($directPermissions);
@@ -21,15 +21,15 @@ class ShieldSeeder extends Seeder
         $this->command->info('Shield Seeding Completed.');
     }
 
-    protected static function makeRolesWithPermissions(string $rolesWithPermissions): void
+    protected static function makeRolesWithPermissions(array $rolesWithPermissions): void
     {
-        if (! blank($rolePlusPermissions = json_decode($rolesWithPermissions, true))) {
+        if (! blank($rolesWithPermissions)) {
             /** @var Model $roleModel */
             $roleModel = Utils::getRoleModel();
             /** @var Model $permissionModel */
             $permissionModel = Utils::getPermissionModel();
 
-            foreach ($rolePlusPermissions as $rolePlusPermission) {
+            foreach ($rolesWithPermissions as $rolePlusPermission) {
                 $role = $roleModel::firstOrCreate([
                     'name' => $rolePlusPermission['name'],
                     'guard_name' => $rolePlusPermission['guard_name'],
@@ -49,14 +49,14 @@ class ShieldSeeder extends Seeder
         }
     }
 
-    public static function makeDirectPermissions(string $directPermissions): void
+    public static function makeDirectPermissions(array $directPermissions): void
     {
-        if (! blank($permissions = json_decode($directPermissions, true))) {
+        if (! blank($directPermissions)) {
             /** @var Model $permissionModel */
             $permissionModel = Utils::getPermissionModel();
 
-            foreach ($permissions as $permission) {
-                if ($permissionModel::whereName($permission)->doesntExist()) {
+            foreach ($directPermissions as $permission) {
+                if ($permissionModel::whereName($permission['name'])->doesntExist()) {
                     $permissionModel::create([
                         'name' => $permission['name'],
                         'guard_name' => $permission['guard_name'],

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
         "build": "vite build"
     },
     "devDependencies": {
+        "@tailwindcss/forms": "^0.5.11",
+        "@tailwindcss/typography": "^0.5.19",
         "autoprefixer": "^10.4.17",
         "axios": "^1.6.4",
         "laravel-vite-plugin": "^1.0.0",

--- a/resources/css/filament/admin/tailwind.config.js
+++ b/resources/css/filament/admin/tailwind.config.js
@@ -1,0 +1,10 @@
+import preset from '../../../../vendor/filament/filament/tailwind.config.preset'
+
+export default {
+    presets: [preset],
+    content: [
+        './app/Filament/**/*.php',
+        './resources/views/filament/**/*.blade.php',
+        './vendor/filament/**/*.blade.php',
+    ],
+}

--- a/resources/css/filament/admin/theme.css
+++ b/resources/css/filament/admin/theme.css
@@ -1,0 +1,33 @@
+@import '../../../../vendor/filament/filament/resources/css/theme.css';
+
+@config 'tailwind.config.js';
+
+@layer base {
+    .fi-body {
+        background:
+            linear-gradient(180deg, rgba(240, 249, 255, 0.95), rgba(240, 249, 255, 0) 16rem),
+            linear-gradient(180deg, #f8fafc, #eef2f7);
+    }
+
+    .dark .fi-body {
+        background:
+            linear-gradient(180deg, rgba(15, 23, 42, 0.88), rgba(15, 23, 42, 0) 18rem),
+            linear-gradient(180deg, #020617, #0f172a);
+    }
+}
+
+@layer components {
+    .fi-main {
+        @apply rounded-[2rem];
+    }
+
+    .fi-page {
+        @apply gap-y-6;
+    }
+
+    .fi-sidebar-header,
+    .fi-topbar,
+    .fi-sidebar {
+        @apply bg-transparent;
+    }
+}

--- a/resources/views/filament/pages/pos.blade.php
+++ b/resources/views/filament/pages/pos.blade.php
@@ -1,0 +1,5 @@
+<x-filament-panels::page>
+    <div class="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
+        Redirecting to POS...
+    </div>
+</x-filament-panels::page>

--- a/resources/views/filament/resources/order-resource/pages/create-order.blade.php
+++ b/resources/views/filament/resources/order-resource/pages/create-order.blade.php
@@ -1,0 +1,129 @@
+<x-filament-panels::page
+    @class([
+        'fi-resource-create-record-page',
+        'fi-resource-' . str_replace('/', '-', $this->getResource()::getSlug()),
+    ])
+>
+    <div class="absolute inset-x-0 top-0 -z-10 h-40 bg-[linear-gradient(180deg,_rgba(240,249,255,0.95),_rgba(240,249,255,0))] dark:bg-[linear-gradient(180deg,_rgba(15,23,42,0.85),_rgba(15,23,42,0))]"></div>
+
+    <div class="grid gap-6 xl:grid-cols-[minmax(0,1fr)_24rem]">
+        <x-filament-panels::form
+            id="form"
+            :wire:key="$this->getId() . '.forms.' . $this->getFormStatePath()"
+            wire:submit="create"
+        >
+            <div class="space-y-6">
+                <section class="rounded-[1.5rem] border border-slate-200/70 bg-white/92 px-6 py-6 shadow-[0_18px_60px_-38px_rgba(15,23,42,0.35)] ring-1 ring-slate-200/60 dark:border-slate-800 dark:bg-slate-900/88 dark:ring-slate-700/60">
+                    <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+                        <div>
+                            <p class="text-[0.7rem] font-semibold uppercase tracking-[0.32em] text-sky-700 dark:text-sky-300">Point Of Sale</p>
+                            <h2 class="mt-2 text-3xl font-semibold tracking-tight text-slate-950 dark:text-white">Create order</h2>
+                            <p class="mt-2 max-w-2xl text-sm leading-6 text-slate-600 dark:text-slate-300">
+                                Add products, optionally attach a client, then complete the sale.
+                            </p>
+                        </div>
+                        <span class="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-600 dark:border-slate-700 dark:bg-slate-950/40 dark:text-slate-300">
+                            Shortcut: Ctrl/Cmd + S
+                        </span>
+                    </div>
+                </section>
+
+                <section class="rounded-[1.5rem] border border-slate-200/70 bg-white/92 p-3 shadow-[0_18px_60px_-38px_rgba(15,23,42,0.38)] ring-1 ring-slate-200/60 dark:border-slate-800 dark:bg-slate-900/88 dark:ring-slate-700/60">
+                    <div class="rounded-[1.2rem] bg-slate-50/75 p-4 dark:bg-slate-950/30">
+                        {{ $this->form }}
+                        <x-filament-panels::form.actions
+                            :actions="$this->getCachedFormActions()"
+                            :full-width="$this->hasFullWidthFormActions()"
+                        />
+                    </div>
+                </section>
+            </div>
+        </x-filament-panels::form>
+
+        <aside class="space-y-6 xl:sticky xl:top-6">
+            <section class="overflow-hidden rounded-[1.5rem] border border-slate-200/70 bg-white/92 shadow-[0_18px_60px_-38px_rgba(15,23,42,0.4)] ring-1 ring-slate-200/60 dark:border-slate-800 dark:bg-slate-900/88 dark:ring-slate-700/60">
+                <div class="border-b border-slate-200/70 bg-slate-50/80 px-6 py-5 dark:border-slate-800 dark:bg-slate-950/35">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <p class="text-xs font-semibold uppercase tracking-[0.28em] text-slate-500 dark:text-slate-400">Live receipt</p>
+                            <h3 class="mt-2 text-xl font-semibold text-slate-950 dark:text-white">Sale summary</h3>
+                        </div>
+                        <span class="rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-xs font-semibold text-sky-700 dark:border-sky-500/20 dark:bg-sky-500/10 dark:text-sky-300">
+                            {{ $this->getCartQuantity() }} units
+                        </span>
+                    </div>
+                </div>
+
+                <div class="px-6 py-5">
+                    <div class="mb-5 flex items-center justify-between rounded-2xl bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:bg-slate-950/35 dark:text-slate-300">
+                        <span>{{ count($this->getCartItems()) }} line(s)</span>
+                        <span>{{ $this->getCartQuantity() }} unit(s)</span>
+                    </div>
+
+                    <div class="space-y-3">
+                        @forelse ($this->getCartItems() as $item)
+                            <div class="rounded-2xl border border-slate-200/70 bg-[linear-gradient(180deg,_rgba(248,250,252,0.95),_rgba(241,245,249,0.88))] p-4 dark:border-slate-800 dark:bg-[linear-gradient(180deg,_rgba(30,41,59,0.72),_rgba(15,23,42,0.82))]">
+                                <div class="flex items-start justify-between gap-4">
+                                    <div>
+                                        <p class="font-medium text-slate-950 dark:text-white">{{ $item['name'] }}</p>
+                                        <div class="mt-2 flex flex-wrap gap-2">
+                                            <span class="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-slate-600 shadow-sm dark:bg-slate-900 dark:text-slate-300">
+                                                Qty {{ $item['quantity'] }}
+                                            </span>
+                                            <span class="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-slate-600 shadow-sm dark:bg-slate-900 dark:text-slate-300">
+                                                {{ number_format($item['price'], 2) }} XFA each
+                                            </span>
+                                        </div>
+                                    </div>
+                                    <p class="text-right text-base font-semibold text-slate-950 dark:text-white">{{ number_format($item['line_total'], 2) }} XFA</p>
+                                </div>
+                            </div>
+                        @empty
+                            <div class="rounded-2xl border border-dashed border-slate-300 bg-slate-50/70 p-5 text-sm leading-6 text-slate-500 dark:border-slate-700 dark:bg-slate-950/30 dark:text-slate-400">
+                                Select products to build the cart. Each line added on the left appears here immediately as a clean receipt preview.
+                            </div>
+                        @endforelse
+                    </div>
+
+                    <div class="mt-6 rounded-[1.4rem] bg-slate-950 px-5 py-4 text-white shadow-lg dark:bg-slate-100 dark:text-slate-950">
+                        <div class="flex items-center justify-between text-sm text-white/70 dark:text-slate-600">
+                            <span>Amount due</span>
+                            <span>{{ $this->getCartQuantity() }} unit(s)</span>
+                        </div>
+                        <div class="mt-2 flex items-end justify-between gap-4">
+                            <span class="text-3xl font-semibold tracking-tight">{{ number_format($this->getCartTotal(), 2) }} XFA</span>
+                        </div>
+                    </div>
+
+                    @if ($client = $this->getSelectedClient())
+                        <div class="mt-6 rounded-2xl bg-slate-50/85 p-5 dark:bg-slate-950/35">
+                            <div class="mb-3 flex items-center justify-between">
+                                <p class="text-sm font-semibold text-slate-950 dark:text-white">Client</p>
+                                <span class="rounded-full border border-slate-200 px-2.5 py-1 text-[11px] font-semibold text-slate-600 dark:border-slate-700 dark:text-slate-300">
+                                    Registered
+                                </span>
+                            </div>
+                            <p class="text-lg font-semibold text-slate-950 dark:text-white">{{ $client->name }}</p>
+                            <div class="mt-4 space-y-3 text-sm text-slate-600 dark:text-slate-300">
+                                <div class="flex items-center justify-between gap-4 border-b border-slate-200/70 pb-3 dark:border-slate-800">
+                                    <span class="uppercase tracking-[0.22em] text-xs text-slate-400 dark:text-slate-500">Phone</span>
+                                    <span class="text-right">{{ $client->phone ?: 'No phone on file' }}</span>
+                                </div>
+                                <div class="flex items-start justify-between gap-4">
+                                    <span class="uppercase tracking-[0.22em] text-xs text-slate-400 dark:text-slate-500">Address</span>
+                                    <span class="max-w-[14rem] text-right">{{ $client->address ?: 'No address on file' }}</span>
+                                </div>
+                            </div>
+                        </div>
+                    @else
+                        <div class="mt-6 rounded-2xl border border-dashed border-slate-300 bg-slate-50/70 p-5 text-sm leading-6 text-slate-500 dark:border-slate-700 dark:bg-slate-950/30 dark:text-slate-400">
+                            This sale will be saved as a walk-in order unless you attach a saved client from the form.
+                        </div>
+                    @endif
+                </div>
+            </section>
+        </aside>
+    </div>
+
+    <x-filament-panels::page.unsaved-data-changes-alert />
+</x-filament-panels::page>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,11 @@ import laravel from 'laravel-vite-plugin';
 export default defineConfig({
     plugins: [
         laravel({
-            input: ['resources/css/app.css', 'resources/js/app.js'],
+            input: [
+                'resources/css/app.css',
+                'resources/css/filament/admin/theme.css',
+                'resources/js/app.js',
+            ],
             refresh: true,
         }),
     ],


### PR DESCRIPTION
# Summary

This PR combines three related changes into one deliverable:

1. Introduces a dedicated `clients` domain model and moves customer data ownership from `orders` to `clients`.
2. Refactors order management to support a dedicated POS entry point and a simpler orders listing experience.
3. Extracts seeded roles and permissions into configuration and adds the required access entries for the new POS navigation flow.

In addition, this PR adds a Filament theme layer so the POS visual treatment can be reused across the panel, improves order item counting/display, and updates seed/build paths to support the new structure.

# Why

The existing implementation stored client data directly on the `orders` table, which made customer reuse and management difficult.

Order creation also mixed CRUD-style resource behavior with POS-style interaction, which made the create flow harder to optimize independently from the orders index.

Finally, hard-coded permissions in the seeder were becoming difficult to maintain as resources/pages changed.

# Main Changes

## 1. Client Module Extraction

Added a full `Client` domain module:

- `app/Models/Client.php`
- `app/Policies/ClientPolicy.php`
- `app/Filament/Resources/ClientResource.php`
- `app/Filament/Resources/ClientResource/Pages/*`
- `database/factories/ClientFactory.php`

Database changes:

- Added `database/migrations/2026_03_29_120000_create_clients_table_and_move_order_clients.php`
- Added `clients` table
- Added nullable `orders.client_id`
- Migrated existing `orders.client_name`, `orders.client_phone`, and `orders.client_address` into `clients`
- Dropped inline client columns from `orders`

Order model changes:

- `Order` now belongs to `Client`
- `client_id` is now the source of customer linkage
- `orders` can still be created without a client for walk-in sales

## 2. POS Create Flow

Created a dedicated POS navigation entry:

- `app/Filament/Pages/Pos.php`
- `resources/views/filament/pages/pos.blade.php`

Behavior:

- POS appears as its own menu item
- POS redirects to the order create route
- POS access is permission-aware via `page_Pos`
- The orders list no longer exposes create directly from the index page

Order creation UX changes:

- `resources/views/filament/resources/order-resource/pages/create-order.blade.php`
- `app/Filament/Resources/OrderResource/Pages/CreateOrder.php`
- `app/Filament/Resources/OrderResource.php`

What changed:

- Added a dedicated POS layout instead of relying only on the default resource create view
- Kept the earlier left-form/right-summary layout for POS
- Simplified duplicate summaries so the sale summary lives in one place
- Improved product row spacing
- Increased space allocated to product selection
- Enlarged the quantity input and made it more prominent
- Added live cart summary rendering
- Added client preview handling in the POS summary area
- Preserved walk-in customer behavior

## 3. Orders Listing Simplification

Updated the orders resource so the index is more table-oriented and details live in view/edit:

- `app/Filament/Resources/OrderResource.php`
- `app/Filament/Resources/OrderResource/Pages/ListOrders.php`
- `app/Filament/Resources/OrderResource/Pages/EditOrder.php`

What changed:

- Orders index is focused on table display
- Create action was removed from the orders list header
- Order view/edit remain available
- Client display now falls back to `Walk-in customer`
- Client search on orders is explicit via client name/phone/address
- Item count is now computed explicitly from related order products instead of depending on the previous generic count shortcut

## 4. Stock Validation and Synchronization

Centralized stock handling into:

- `app/Support/Orders/OrderStockManager.php`

This removes duplicated logic between create and edit flows and makes stock updates more predictable.

What it now handles:

- Validation of requested quantities before save
- Inventory synchronization after create/edit
- Reconciliation against original order quantities during updates

## 5. Order Item Counting / Display Fixes

Updated:

- `app/Models/OrderProduct.php`
- `app/Filament/Resources/OrderResource.php`

Fixes:

- `OrderProduct` now uses `SoftDeletes`, matching the table schema
- Deleted line items are no longer candidates for item counts
- Order table item counts are explicitly derived from the relation

## 6. Access Control Refactor

Added:

- `config/access.php`

Updated:

- `database/seeders/ShieldSeeder.php`

What changed:

- Roles and permissions are no longer hard-coded as JSON inside the seeder
- Seeder now reads role and permission definitions from config
- Added the required `page_Pos` permission for the dedicated POS page

## 7. Filament Panel / Theme Updates

Updated:

- `app/Providers/Filament/AdminPanelProvider.php`
- `resources/css/filament/admin/theme.css`
- `resources/css/filament/admin/tailwind.config.js`
- `vite.config.js`
- `package.json`
- `package-lock.json`

What changed:

- Added a Filament admin theme build entry
- Added Tailwind plugins required by Filament theme compilation
- Applied the POS-inspired soft background/gradient treatment panel-wide
- Enabled collapsible sidebar behavior on desktop
- Configured navigation groups for Sales, Stocks, and Users

# Seeder / Factory Changes

Updated:

- `database/factories/OrderFactory.php`
- `database/seeders/DatabaseSeeder.php`
- `database/seeders/OrderSeeder.php`
- `database/seeders/ProductCategorySeeder.php`
- `database/seeders/ProductSeeder.php`
- `database/seeders/ProductSupplierSeeder.php`

Notes:

- `OrderFactory` now targets `client_id`
- Seeder flow was adjusted around the new access configuration
- The current order seeding path is part of the uncommitted set and should be reviewed as part of this PR, especially if seeded orders are expected to always include line items

# File Impact

## Added

- `app/Filament/Pages/Pos.php`
- `app/Filament/Resources/ClientResource.php`
- `app/Filament/Resources/ClientResource/Pages/CreateClient.php`
- `app/Filament/Resources/ClientResource/Pages/EditClient.php`
- `app/Filament/Resources/ClientResource/Pages/ListClients.php`
- `app/Filament/Resources/ClientResource/Pages/ViewClient.php`
- `app/Models/Client.php`
- `app/Policies/ClientPolicy.php`
- `app/Support/Orders/OrderStockManager.php`
- `config/access.php`
- `database/factories/ClientFactory.php`
- `database/migrations/2026_03_29_120000_create_clients_table_and_move_order_clients.php`
- `resources/css/filament/admin/theme.css`
- `resources/css/filament/admin/tailwind.config.js`
- `resources/views/filament/pages/pos.blade.php`
- `resources/views/filament/resources/order-resource/pages/create-order.blade.php`

## Modified

- `app/Filament/Resources/OrderResource.php`
- `app/Filament/Resources/OrderResource/Pages/CreateOrder.php`
- `app/Filament/Resources/OrderResource/Pages/EditOrder.php`
- `app/Filament/Resources/OrderResource/Pages/ListOrders.php`
- `app/Models/Order.php`
- `app/Models/OrderProduct.php`
- `app/Providers/Filament/AdminPanelProvider.php`
- `database/factories/OrderFactory.php`
- `database/migrations/2024_02_19_085020_create_orders_table.php`
- `database/seeders/DatabaseSeeder.php`
- `database/seeders/OrderSeeder.php`
- `database/seeders/ProductCategorySeeder.php`
- `database/seeders/ProductSeeder.php`
- `database/seeders/ProductSupplierSeeder.php`
- `database/seeders/ShieldSeeder.php`
- `package.json`
- `package-lock.json`
- `vite.config.js`
- `composer.lock`

# Migration Notes

Run:

```bash
php artisan migrate
```

This PR includes a data migration that:

- creates `clients`
- adds nullable `orders.client_id`
- migrates existing order client details into clients
- removes old client columns from `orders`

# Seeding Notes

Run:

```bash
php artisan db:seed --class=ShieldSeeder
php artisan db:seed
```

Important:

- This PR introduces `config/access.php` as the source of truth for seeded roles/permissions
- The POS page requires `page_Pos`
- The seeding flow should be validated together with role assignment order and seeded order item creation expectations

# Frontend / Build Notes

Run:

```bash
npm install
npm run build
```

The panel now depends on the Filament admin theme build entry:

- `resources/css/filament/admin/theme.css`

# Testing / Verification Performed

The following checks were performed during implementation:

- syntax validation with `php -l` on changed PHP files
- route verification for the POS page and order create route
- `npm run build` for the Filament theme bundle
- migration + seeding flow was manually exercised in the local environment during development


